### PR TITLE
(doc) fix #31 - rename `createComputed` → `bind`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ LocalStorage plugin inspired by Vue typed props which take a care of typecasting
 ## Usage
   ``` js
   import VueLocalStorage from 'vue-localstorage'
-  
+
   Vue.use(VueLocalStorage)
   // Or you can specify any other name and use it via this.$ls, this.$whatEverYouWant
   Vue.use(VueLocalStorage, {
     name: 'ls',
-    createComputed: true //created computed members from your variable declarations
+    bind: true //created computed members from your variable declarations
   })
 
   // Use localStorage from Vue object
@@ -32,7 +32,7 @@ LocalStorage plugin inspired by Vue typed props which take a care of typecasting
 
   // Fallback value if nothing found in localStorage
   Vue.localStorage.get('propertyThatNotExists', 'fallbackValue') // Will return 'fallbackValue' string
-  
+
   //register localStorage variables and adds computed variables to local components
   //to be used like regular computeds that are stored in the localstorage
   var vm = new Vue({


### PR DESCRIPTION
fe7b085 renamed `createComputed` to `bind`, but this change was not reflected in the doc