### PR TITLE
Support for browsers not having Array.includes

### DIFF
--- a/src/VueLocalStorage.js
+++ b/src/VueLocalStorage.js
@@ -47,7 +47,8 @@ class VueLocalStorage {
    */
   _lsSet (lsKey, rawValue, type) {
     const key = this._getLsKey(lsKey)
-    const value = type && [Array, Object].includes(type)
+    const jsonTypes = [Array, Object]
+    const value = type && (jsonTypes.includes ? jsonTypes.includes(type) : (jsonTypes.indexOf(type) != -1))
       ? JSON.stringify(rawValue)
       : rawValue
 


### PR DESCRIPTION
Browsers missing Array.includes API fail to persist data in localStorage. This is a fix to address it.