### PR TITLE
Return defaultValue if local storage is not supported

### DIFF
--- a/src/VueLocalStorage.js
+++ b/src/VueLocalStorage.js
@@ -77,7 +77,7 @@ class VueLocalStorage {
    */
   get (lsKey, defaultValue = null, defaultType = String) {
     if (!this._isSupported) {
-      return null
+      return defaultValue
     }
 
     if (this._lsGet(lsKey)) {


### PR DESCRIPTION
Instead of having to check if local storage is enabled, provide a default value if not, AND provide a default value if the key doesn't exist, I think it would be useful to return the default value if provided when local storage is not enabled.